### PR TITLE
Use File$toURI to convert dir-path into URI

### DIFF
--- a/src/clucie/store.clj
+++ b/src/clucie/store.clj
@@ -1,5 +1,6 @@
 (ns clucie.store
-  (:require [clucie.analysis :refer [standard-analyzer]])
+  (:require [clojure.java.io :as io]
+            [clucie.analysis :refer [standard-analyzer]])
   (:import [java.io StringReader File]
            [java.nio.file Paths]
            [org.apache.lucene.analysis Analyzer]
@@ -14,8 +15,8 @@
 
 (defn disk-store
   "Create a new index in a directory on disk."
-  [^String dir-path]
-  (NIOFSDirectory. (Paths/get (java.net.URI. (str "file://" dir-path)))))
+  [dir-path]
+  (NIOFSDirectory. (Paths/get (.toURI (io/file dir-path)))))
 
 (defn store-writer
   "Create an IndexWriter."


### PR DESCRIPTION
Current `store/disk-store` cannot receive a relative path:

``` clojure
(store/disk-store "./foo")
=> IllegalArgumentException URI has an authority component  sun.nio.fs.UnixUriUtils.fromUri (UnixUriUtils.java:53)
```

This PR fixes this problem by using [File$toURI](https://docs.oracle.com/javase/7/docs/api/java/io/File.html#toURI%28%29).
