### PR TITLE
Ignore nil or an empty string in a set of OR search

### DIFF
--- a/src/clucie/core.clj
+++ b/src/clucie/core.clj
@@ -100,7 +100,8 @@
                                (.build qb))
     (set? query-form) (let [qb (new org.apache.lucene.search.BooleanQuery$Builder)]
                         (doseq [q (map #(query-form->query % builder :current-key current-key) query-form)]
-                          (.add qb q BooleanClause$Occur/SHOULD))
+                          (when q
+                            (.add qb q BooleanClause$Occur/SHOULD)))
                         (.build qb))
     (map? query-form) (let [qb (new org.apache.lucene.search.BooleanQuery$Builder)]
                         (doseq [q (->> query-form


### PR DESCRIPTION
This fixes a problem occurring when a set including `nil` or an empty string is passed to `search`.

Before:

```clojure
(core/search index-store {:title #{"Beatles" nil}} 10 analyzer 0 5)
;; NullPointerException Query must not be null  java.util.Objects.requireNonNull (Objects.java:228)

(core/search index-store {:title #{"Beatles" ""}} 10 analyzer 0 5)
;; NullPointerException Query must not be null  java.util.Objects.requireNonNull (Objects.java:228)
```

After:

```clojure
(core/search index-store {:title #{"Beatles" nil}} 10 analyzer 0 5)
=> [{:number "2", :title "With the Beatles"} {:number "4", :title "Beatles for Sale"}]

(core/search index-store {:title #{"Beatles" ""}} 10 analyzer 0 5)
=> [{:number "2", :title "With the Beatles"} {:number "4", :title "Beatles for Sale"}]
```