### PR TITLE
Search with raw Query instance

### DIFF
--- a/src/clucie/core.clj
+++ b/src/clucie/core.clj
@@ -94,6 +94,7 @@
   [mode query-form ^QueryBuilder builder & {:keys [current-key]
                                        :or {current-key nil}}]
   (cond
+    (instance? Query query-form) query-form
     (sequential? query-form) (let [qb (new org.apache.lucene.search.BooleanQuery$Builder)]
                                (doseq [q (map #(query-form->query mode % builder :current-key current-key) query-form)]
                                  (when q


### PR DESCRIPTION
clucie is good at wrapping query, but it is hard to use advanced search in a user's environment because current clucie does not allow raw Query instance (`org.apache.lucene.search.Query`). `query-form->query` returns `Query` as it is if `query-form` is `Query` by this PR.