### PR TITLE
Support preprocessing in build-analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ To tokenize,
   (analysis/kuromoji-tokenize text user-dict discard-punctuation? mode factory)) ; => ("富士" "は" "日本一" "の" "山")
 ```
 
+## To build analyzer
+
+This code builds an analyzer that normalizes input texts, then splits texts into words, and finally generates n-grams.
+
+```clojure
+(analysis/build-analyzer
+  (JapaneseTokenizer. nil true JapaneseTokenizer$Mode/NORMAL)
+  :char-filter-factories [(ICUNormalizer2CharFilterFactory. (HashMap. {"name" "nfkc", "mode" "compose"}))]
+  :token-filters [(LowerCaseFilter.)
+                  (max-shingle/MaxShingleFilter. 3 " ")])
+```
+
 # Run tests
 
 Run `lein midje`.

--- a/src/clucie/analysis.clj
+++ b/src/clucie/analysis.clj
@@ -11,24 +11,17 @@
            [java.io StringReader]))
 
 (defmacro build-analyzer
-  [tokenizer & filters]
+  [tokenizer & {:keys [char-filter-factories token-filters]}]
   `(proxy [Analyzer] []
      (createComponents [field-name#]
        (let [src# ~tokenizer
              token# (-> src#
-                        ~@filters)]
-         (Analyzer$TokenStreamComponents. src# token#)))))
-
-(defmacro build-analyzer-with-charfilter
-  [charfilter-factory tokenizer & filters]
-  `(proxy [Analyzer] []
-     (createComponents [field-name#]
-       (let [src# ~tokenizer
-             token# (-> src#
-                        ~@filters)]
+                        ~@token-filters)]
          (Analyzer$TokenStreamComponents. src# token#)))
      (initReader [field-name# reader#]
-       (proxy-super initReader field-name# (.create ~charfilter-factory reader#)))))
+       (proxy-super initReader
+                    field-name#
+                    (reduce #(.create %2 %1) reader# ~char-filter-factories)))))
 
 (defn- char-set
   (^CharArraySet [stop-words]
@@ -50,10 +43,10 @@
 (defn ngram-analyzer
   [min-length max-length stop-words]
   (build-analyzer (NGramTokenizer. min-length max-length)
-                  (NGramTokenFilter. min-length max-length)
-                  ;; (StandardFilter.) ; is it necessary?
-                  (LowerCaseFilter.)
-                  (StopFilter. (char-set stop-words))))
+                  :token-filters [(NGramTokenFilter. min-length max-length)
+                                  ;; (StandardFilter.) ; is it necessary?
+                                  (LowerCaseFilter.)
+                                  (StopFilter. (char-set stop-words))]))
 
 (defn cjk-analyzer
   (^org.apache.lucene.analysis.Analyzer []

--- a/src/clucie/analysis.clj
+++ b/src/clucie/analysis.clj
@@ -19,6 +19,17 @@
                         ~@filters)]
          (Analyzer$TokenStreamComponents. src# token#)))))
 
+(defmacro build-analyzer-with-charfilter
+  [charfilter-factory tokenizer & filters]
+  `(proxy [Analyzer] []
+     (createComponents [field-name#]
+       (let [src# ~tokenizer
+             token# (-> src#
+                        ~@filters)]
+         (Analyzer$TokenStreamComponents. src# token#)))
+     (initReader [field-name# reader#]
+       (proxy-super initReader field-name# (.create ~charfilter-factory reader#)))))
+
 (defn- char-set
   (^CharArraySet [stop-words]
    (char-set stop-words false))

--- a/test/clucie/t_common.clj
+++ b/test/clucie/t_common.clj
@@ -7,7 +7,11 @@
             [clucie.analysis :as analysis]
             [clucie.store :as store])
   (:import [java.util UUID]
-           [java.io File]))
+           [java.util HashMap]
+           [java.io File]
+           [org.apache.lucene.analysis.core LowerCaseFilter]
+           [org.apache.lucene.analysis.icu ICUNormalizer2CharFilterFactory]
+           [org.apache.lucene.analysis.standard StandardTokenizer]))
 
 (def test-store (atom nil))
 (def doc-analyzer (atom nil))
@@ -17,6 +21,9 @@
 (def cjk-analyzer (analysis/cjk-analyzer))
 (def kuromoji-analyzer (analysis/kuromoji-analyzer))
 (def ngram-analyzer (analysis/ngram-analyzer 2 8 []))
+(def built-analyzer (analysis/build-analyzer (StandardTokenizer.)
+                                             :char-filter-factories [(ICUNormalizer2CharFilterFactory. (HashMap. {}))]
+                                             :token-filters [(LowerCaseFilter.)]))
 
 (defn add-entry! [k document]
   (core/add! @test-store

--- a/test/clucie/t_core.clj
+++ b/test/clucie/t_core.clj
@@ -62,6 +62,14 @@
         (t-common/add-entry! entry-key entry-doc) => nil
         (t-common/search-entries entry-doc 10) => (t-common/results-is-valid? 1 entry-key)))))
 
+(facts "built analyzer"
+  (with-state-changes [(before :facts (t-common/prepare! t-common/built-analyzer nil t-fixture/entries-unnormalized-1))
+                       (after :facts (t-common/finish!))]
+    (fact "search exists entries"
+      (t-common/search-entries t-fixture/entries-unnormalized-1-search-1 10) => (t-common/results-is-valid? 1 (get-in t-fixture/entries-unnormalized-1 [0 0]))
+      (t-common/search-entries t-fixture/entries-unnormalized-1-search-2 10) => (t-common/results-is-valid? 2 (get-in t-fixture/entries-unnormalized-1 [1 0]))
+      (t-common/search-entries t-fixture/entries-unnormalized-1-search-2 10) => (t-common/results-is-valid? 2 (get-in t-fixture/entries-unnormalized-1 [2 0])))))
+
 (facts "ngram analyzer (en)"
   (with-state-changes [(before :facts (t-common/prepare! t-common/ngram-analyzer nil t-fixture/entries-en-1))
                        (after :facts (t-common/finish!))]

--- a/test/clucie/t_fixture.clj
+++ b/test/clucie/t_fixture.clj
@@ -5,6 +5,14 @@
             [clucie.t-common :as t-common])
   (:import [org.apache.lucene.queryparser.classic ParseException]))
 
+(def entries-unnormalized-1
+  [["1" "ＦＵＬＬ　ｗｉｄｔｈ　ＳＥＮＴＥＮＣＥ"]
+   ["2" "Composed hat A: \u00c2:"]
+   ["3" "Decomposed hat A: A\u0302"]])
+
+(def entries-unnormalized-1-search-1 "sentence")
+(def entries-unnormalized-1-search-2 "\u00c2")
+
 (def entries-en-1
   [["1" "20130819"]
    ["2" "Hello"]


### PR DESCRIPTION
For example, the following code normalizes documents or queries before splitting into words.
```clojure
(build-analyzer-with-charfilter
  (ICUNormalizer2CharFilterFactory. (HashMap. {"name" "nfkc_cf", "mode" "compose"}))
  (JapaneseTokenizer. nil true JapaneseTokenizer$Mode/NORMAL)
  (LowerCaseFilter.))
```