### PR TITLE
Support raw Field add/update

### DIFF
--- a/test/clucie/t_core.clj
+++ b/test/clucie/t_core.clj
@@ -6,6 +6,7 @@
             [clucie.t-common :as t-common]
             [clucie.t-fixture :as t-fixture])
   (:import [java.util UUID]
+           [org.apache.lucene.document Document Field$Store StringField]
            [org.apache.lucene.queryparser.flexible.standard StandardQueryParser]))
 
 (defmacro run-testset! [testset-symbol]
@@ -351,3 +352,15 @@
       (store/close! @t-common/test-store)
       (reset! t-common/test-store (store/disk-store tmp-store-path))
       (t-common/search-entries doc 10) => (t-common/results-is-valid? 1 k))))
+
+(facts "map->document"
+  (tabular
+   (fact "returns org.apache.lucene.document.Document"
+     (#'core/map->document ?m ?ks) => #(instance? Document %))
+   ?m ?ks
+   {:key "123", :doc "abc"} [:key :doc]
+   {:key 123, :doc "abc"} [:key :doc]
+   {:key :123, :doc "abc"} [:key :doc]
+   {:key "123", ::core/raw-fields [(StringField. "doc" "abc" Field$Store/YES)]} [:key])
+  (fact "throws exception"
+    (#'core/map->document {:key "123", ::core/raw-fields [{:doc "abc"}]} [:key]) => (throws Exception)))


### PR DESCRIPTION
`add!`/`update!` newly supports raw `org.apache.lucene.document.Field` instances.

e.g.

```clojure
(require '[clucie.core :as clucie])
(import '[org.apache.lucene.document Field$Store StringField])

(clucie/add! index-store
             [{:number "1"
               :title "Please Please Me"
               ::clucie/raw-fields [(StringField. "artist" "The Beatles" Field$Store/YES)]}]
             [:number :title]
             analyzer)
```

This enables us to use advanced field manipulations. I selected a qualified keyword, `:clucie.core/raw-fields`, as the key name for avoiding conflicts.