### PR TITLE
Add separated namespace for document

### DIFF
--- a/src/clucie/document.clj
+++ b/src/clucie/document.clj
@@ -1,0 +1,61 @@
+(ns clucie.document
+  (:import [org.apache.lucene.document Document Field FieldType]
+           [org.apache.lucene.index IndexOptions]))
+
+(defn- estimate-value
+  [v]
+  (cond
+    (string? v) {:value v :value-type :string}
+    (integer? v) {:value (str v) :value-type :integer}
+    (keyword? v) {:value (name v) :value-type :keyword}
+    :else {:value (str v) :value-type :unknown}))
+
+(defn ^FieldType field-type
+  "Creates an org.apache.lucene.document.FieldType according to given map:
+
+    {:indexed?    Set true if the field should be indexed, default false. This
+                  accepts an org.apache.lucene.index.IndexOptions constant other
+                  than boolean value.
+     :stored?     Set true if the field should be stored, default true.
+     :tokenized?  Set true if the field should be tokenized, default false.}"
+  [{:keys [indexed? stored? tokenized?]
+    :or {indexed? false, stored? true, tokenized? false}}]
+  (let [index-opt (cond
+                    (true? indexed?) IndexOptions/DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS
+                    (false? indexed?) IndexOptions/NONE
+                    :else indexed?)]
+    (doto (FieldType.)
+      (.setIndexOptions index-opt)
+      (.setStored stored?)
+      (.setTokenized tokenized?))))
+
+(defn ^Field field
+  "Creates an org.apache.lucene.document.Field from key and value. opts is an
+  optional map specifying type of the field, which is passed to field-type
+  function as it is. See also docs of field-type for further details."
+  ([key value] (field key value {}))
+  ([key value opts]
+   (let [{:keys [^String value]} (estimate-value value)]
+     (Field. (name key) value (field-type opts)))))
+
+(defn ^Document document
+  "Creates an org.apache.lucene.document.Document from a map. The map can
+  optionally includes :clucie.core/raw-fields key, which value must be a
+  sequence of raw org.apache.lucene.document.Field instances."
+  [m keys]
+  (let [doc (Document.)
+        fs (concat (map (fn [[k v]]
+                          (field k v {:indexed? (contains? keys k)
+                                      :stored? true
+                                      :tokenized? (contains? keys k)}))
+                        (dissoc m :clucie.core/raw-fields))
+                   (:clucie.core/raw-fields m))]
+    (doseq [^Field f fs]
+      (.add doc f))
+    doc))
+
+(defn document->map
+  "Turns a Document object into a map."
+  [^Document doc]
+  (into {} (for [^Field f (.getFields doc)]
+             [(keyword (.name f)) (.stringValue f)])))

--- a/test/clucie/t_core.clj
+++ b/test/clucie/t_core.clj
@@ -6,7 +6,6 @@
             [clucie.t-common :as t-common]
             [clucie.t-fixture :as t-fixture])
   (:import [java.util UUID]
-           [org.apache.lucene.document Document Field$Store StringField]
            [org.apache.lucene.queryparser.flexible.standard StandardQueryParser]))
 
 (defmacro run-testset! [testset-symbol]
@@ -352,15 +351,3 @@
       (store/close! @t-common/test-store)
       (reset! t-common/test-store (store/disk-store tmp-store-path))
       (t-common/search-entries doc 10) => (t-common/results-is-valid? 1 k))))
-
-(facts "map->document"
-  (tabular
-   (fact "returns org.apache.lucene.document.Document"
-     (#'core/map->document ?m ?ks) => #(instance? Document %))
-   ?m ?ks
-   {:key "123", :doc "abc"} [:key :doc]
-   {:key 123, :doc "abc"} [:key :doc]
-   {:key :123, :doc "abc"} [:key :doc]
-   {:key "123", ::core/raw-fields [(StringField. "doc" "abc" Field$Store/YES)]} [:key])
-  (fact "throws exception"
-    (#'core/map->document {:key "123", ::core/raw-fields [{:doc "abc"}]} [:key]) => (throws Exception)))

--- a/test/clucie/t_document.clj
+++ b/test/clucie/t_document.clj
@@ -1,7 +1,43 @@
 (ns clucie.t-document
   (:require [midje.sweet :refer :all]
             [clucie.document :as doc])
-  (:import [org.apache.lucene.document Document Field$Store StringField]))
+  (:import [org.apache.lucene.document Document Field Field$Store StringField]
+           [org.apache.lucene.index IndexOptions]))
+
+(facts "field-type"
+  (tabular
+   (fact ":indexed?"
+     (.indexOptions (doc/field-type ?map)) => ?expected)
+   ?map                                    ?expected
+   {:indexed? true}                        IndexOptions/DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS
+   {:indexed? false}                       IndexOptions/NONE
+   {:indexed? IndexOptions/DOCS_AND_FREQS} IndexOptions/DOCS_AND_FREQS
+   {}                                      IndexOptions/NONE)
+  (tabular
+   (fact ":stored?"
+     (.stored (doc/field-type ?map)) => ?expected)
+   ?map             ?expected
+   {:stored? true}  truthy
+   {:stored? false} falsey
+   {}               truthy)
+  (tabular
+   (fact ":tokenized?"
+     (.tokenized (doc/field-type ?map)) => ?expected)
+   ?map                ?expected
+   {:tokenized? true}  truthy
+   {:tokenized? false} falsey
+   {}                  falsey))
+
+(facts "field"
+  (tabular
+   (fact "returns org.apache.lucene.document.Field"
+     (doc/field ?k ?v) => #(instance? Field %))
+   ?k   ?v
+   :key "123"
+   "key" 123
+   :key :123)
+  (fact "throws exception"
+    (doc/field nil "123") => (throws Exception)))
 
 (facts "document"
   (tabular
@@ -14,3 +50,6 @@
    {:key "123", :clucie.core/raw-fields [(StringField. "doc" "abc" Field$Store/YES)]} [:key])
   (fact "throws exception"
     (doc/document {:key "123", :clucie.core/raw-fields [{:doc "abc"}]} [:key]) => (throws Exception)))
+
+(fact "document->map"
+  (doc/document->map (doc/document {:key "123", :doc "abc"} [:key :doc])) => map?)

--- a/test/clucie/t_document.clj
+++ b/test/clucie/t_document.clj
@@ -1,0 +1,16 @@
+(ns clucie.t-document
+  (:require [midje.sweet :refer :all]
+            [clucie.document :as doc])
+  (:import [org.apache.lucene.document Document Field$Store StringField]))
+
+(facts "document"
+  (tabular
+   (fact "returns org.apache.lucene.document.Document"
+     (doc/document ?m ?ks) => #(instance? Document %))
+   ?m ?ks
+   {:key "123", :doc "abc"} [:key :doc]
+   {:key 123, :doc "abc"} [:key :doc]
+   {:key :123, :doc "abc"} [:key :doc]
+   {:key "123", :clucie.core/raw-fields [(StringField. "doc" "abc" Field$Store/YES)]} [:key])
+  (fact "throws exception"
+    (doc/document {:key "123", :clucie.core/raw-fields [{:doc "abc"}]} [:key]) => (throws Exception)))


### PR DESCRIPTION
Adds a new namespace, `clucie.document`, for document-related features.

I moved `Document/Field/FieldType` generators and `Document -> map` converter from `clucie.core`. Arities and docstrings of these functions were reconsidered, and now they can be easily used as public functions. In the near future, I'd like to add useful wrappers of sugar fields, such as `StringField` and `SortedNumericDocValuesField`.