### PR TITLE
Add arity for reader/writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,26 @@ The following example builds an analyzer that normalizes input texts, splits tex
                   (max-shingle/MaxShingleFilter. 3 " ")])
 ```
 
+## Reusing connections
+
+By default, update/search functions create a new writer/reader each time,
+however, that is somewhat inefficient and not thread-safe. For high performance
+or concurrent processing, you can pass directly a writer/reader to them.
+
+```clojure
+(with-open [writer (store/store-writer index-store analyzer)]
+  (core/add! writer
+             [{:number "1" :title "Please Please Me"}
+              {:number "2" :title "With the Beatles"}]
+             [:number :title]))
+
+(with-open [reader (store/store-reader index-store)]
+  (core/search reader
+               {:title "Beatles"}
+               10
+               analyzer))
+```
+
 # Run tests
 
 Run `lein midje`.

--- a/src/clucie/store.clj
+++ b/src/clucie/store.clj
@@ -1,32 +1,33 @@
 (ns clucie.store
-  (:require [clojure.java.io :as io]
-            [clucie.analysis :refer [standard-analyzer]])
-  (:import [java.io StringReader File]
-           [java.nio.file Paths]
+  (:require [clojure.java.io :as io])
+  (:import [java.nio.file Paths]
            [org.apache.lucene.analysis Analyzer]
            [org.apache.lucene.store NIOFSDirectory RAMDirectory Directory]
-           [org.apache.lucene.index IndexWriter IndexWriterConfig IndexReader DirectoryReader]
-           [org.apache.lucene.util Version]))
+           [org.apache.lucene.index IndexWriter IndexWriterConfig IndexReader DirectoryReader]))
 
 (defn memory-store
   "Create a new index in RAM."
+  ^org.apache.lucene.store.RAMDirectory
   []
   (RAMDirectory.))
 
 (defn disk-store
   "Create a new index in a directory on disk."
+  ^org.apache.lucene.store.NIOFSDirectory
   [dir-path]
   (NIOFSDirectory. (Paths/get (.toURI (io/file dir-path)))))
 
 (defn store-writer
   "Create an IndexWriter."
-  ^IndexWriter [index ^Analyzer analyzer]
+  ^org.apache.lucene.index.IndexWriter
+  [index ^Analyzer analyzer]
   (IndexWriter. index (IndexWriterConfig. analyzer)))
 
 (defn store-reader
   "Create an IndexReader."
-  ^IndexReader [index]
-  (DirectoryReader/open ^Directory index))
+  ^org.apache.lucene.index.IndexReader
+  [^Directory index]
+  (DirectoryReader/open index))
 
 (defn close!
   "Close an index."

--- a/test/clucie/t_core.clj
+++ b/test/clucie/t_core.clj
@@ -388,3 +388,18 @@
       (with-open [writer (store/store-writer @t-common/test-store (analysis/standard-analyzer))]
         (core/delete! writer :key "1") => nil?
         (core/delete! writer :key "2" (analysis/standard-analyzer)) => (throws clojure.lang.ArityException)))))
+
+(facts "search*"
+  (with-state-changes [(before :facts (t-common/prepare! (analysis/standard-analyzer) nil t-fixture/entries-en-1))
+                       (after :facts (t-common/finish!))]
+    (fact "with store"
+      (#'core/search* :query @t-common/test-store
+                      [{:doc t-fixture/entries-en-1-search-1}]
+                      10 (analysis/standard-analyzer) 0 10)
+      => (t-common/results-is-valid? 1 (get-in t-fixture/entries-en-1 [0 0])))
+    (fact "with reader"
+      (with-open [reader (store/store-reader @t-common/test-store)]
+        (#'core/search* :query reader
+                        [{:doc t-fixture/entries-en-1-search-1}]
+                        10 (analysis/standard-analyzer) 0 10)
+        => (t-common/results-is-valid? 1 (get-in t-fixture/entries-en-1 [0 0]))))))

--- a/test/clucie/t_core.clj
+++ b/test/clucie/t_core.clj
@@ -351,3 +351,40 @@
       (store/close! @t-common/test-store)
       (reset! t-common/test-store (store/disk-store tmp-store-path))
       (t-common/search-entries doc 10) => (t-common/results-is-valid? 1 k))))
+
+(facts "add!"
+  (with-state-changes [(before :facts (t-common/prepare! (analysis/standard-analyzer) nil t-fixture/entries-en-1))
+                       (after :facts (t-common/finish!))]
+    (fact "with store"
+      (core/add! @t-common/test-store [{:key "123", :doc "abc"}] [:key :doc]) => nil?
+      (core/add! @t-common/test-store [{:key "456", :doc "def"}] [:key :doc]
+                 (analysis/standard-analyzer)) => nil?)
+    (fact "with writer"
+      (with-open [writer (store/store-writer @t-common/test-store (analysis/standard-analyzer))]
+        (core/add! writer [{:key "123", :doc "abc"}] [:key :doc]) => nil?
+        (core/add! writer [{:key "456", :doc "def"}] [:key :doc]
+                   (analysis/standard-analyzer)) => (throws clojure.lang.ArityException)))))
+
+(facts "update!"
+  (with-state-changes [(before :facts (t-common/prepare! (analysis/standard-analyzer) nil t-fixture/entries-en-1))
+                       (after :facts (t-common/finish!))]
+    (fact "with store"
+      (core/update! @t-common/test-store {:key "2", :doc "Hello world"} [:key :doc] :key "2") => nil?
+      (core/update! @t-common/test-store {:key "3", :doc "Osaka station"} [:key :doc] :key "3"
+                    (analysis/standard-analyzer)) => nil?)
+    (fact "with writer"
+      (with-open [writer (store/store-writer @t-common/test-store (analysis/standard-analyzer))]
+        (core/update! writer {:key "2", :doc "Hello world"} [:key :doc] :key "2") => nil?
+        (core/update! writer {:key "3", :doc "Osaka station"} [:key :doc] :key "3"
+                      (analysis/standard-analyzer)) => (throws clojure.lang.ArityException)))))
+
+(facts "delete!"
+  (with-state-changes [(before :facts (t-common/prepare! (analysis/standard-analyzer) nil t-fixture/entries-en-1))
+                       (after :facts (t-common/finish!))]
+    (fact "with store"
+      (core/delete! @t-common/test-store :key "1") => nil?
+      (core/delete! @t-common/test-store :key "2" (analysis/standard-analyzer)) => nil?)
+    (fact "with writer"
+      (with-open [writer (store/store-writer @t-common/test-store (analysis/standard-analyzer))]
+        (core/delete! writer :key "1") => nil?
+        (core/delete! writer :key "2" (analysis/standard-analyzer)) => (throws clojure.lang.ArityException)))))


### PR DESCRIPTION
Some core functions newly accept reader/writer as one of the arguments: `add!/update!/delete!` support `IndexWriter`, and `search` supports `IndexReader`.

Current the arity receiving store is easy to use and good as a sugar wrapper. However, it is inefficient because open/close of reader/writer is somewhat heavy, especially writer in Lucene. In addition, it makes concurrent processing difficult because a `IndexWriter` instance locks the store.

By this change, we become able to reuse `IndexWriter` and create efficient indexing programs.