### PR TITLE
Add walkers for query

### DIFF
--- a/src/clucie/query.clj
+++ b/src/clucie/query.clj
@@ -1,0 +1,59 @@
+(ns clucie.query
+  (:import [org.apache.lucene.search
+            BooleanClause BooleanQuery BooleanQuery$Builder BoostQuery
+            ConstantScoreQuery DisjunctionMaxQuery Query]))
+
+(defn ^Query walk
+  "Traverses query. inner and outer are functions. Applies inner to each
+  sub-query of query, building up a query of the same type, then applies outer
+  to the result."
+  [inner outer query]
+  (outer
+   (condp instance? query
+     BooleanQuery
+     (let [^BooleanQuery query query
+           qb (BooleanQuery$Builder.)]
+       (doseq [^BooleanClause clause (.clauses query)]
+         (when-let [q (inner (.getQuery clause))]
+           (.add qb q (.getOccur clause))))
+       (.build qb))
+
+     BoostQuery
+     (let [^BoostQuery query query]
+       (when-let [q (inner (.getQuery query))]
+         (BoostQuery. q (.getBoost query))))
+
+     ConstantScoreQuery
+     (let [^ConstantScoreQuery query query]
+       (when-let [q (inner (.getQuery query))]
+         (ConstantScoreQuery. q)))
+
+     DisjunctionMaxQuery
+     (let [^DisjunctionMaxQuery query query]
+       (DisjunctionMaxQuery. (keep inner (.getDisjuncts query))
+                             (.getTieBreakerMultiplier query)))
+
+     query)))
+
+(defn ^Query postwalk
+  "Performs a depth-first, post-order traversal of query. Calls f on each
+  sub-query, uses f's return value in place of the original."
+  [f query]
+  (walk (partial postwalk f) f query))
+
+(defn ^Query prewalk
+  "Like postwalk, but does pre-order traversal."
+  [f query]
+  (walk (partial prewalk f) identity (f query)))
+
+(defn ^Query postwalk-demo
+  "Demonstrates the behavior of postwalk by printing each query as it is walked.
+  Returns query."
+  [query]
+  (postwalk (fn [x] (print "Walked: ") (prn x) x) query))
+
+(defn ^Query prewalk-demo
+  "Demonstrates the behavior of prewalk by printing each query as it is walked.
+  Returns query."
+  [query]
+  (prewalk (fn [x] (print "Walked: ") (prn x) x) query))

--- a/test/clucie/t_query.clj
+++ b/test/clucie/t_query.clj
@@ -1,0 +1,99 @@
+(ns clucie.t-query
+  (:require [midje.sweet :refer :all]
+            [clucie.query :as query])
+  (:import [org.apache.lucene.index Term]
+           [org.apache.lucene.search
+            BooleanClause$Occur BooleanQuery$Builder BoostQuery
+            ConstantScoreQuery DisjunctionMaxQuery Query TermQuery]))
+
+;; a:1 (+b:2 +c:3) (d:4)^2.0 ConstantScore(e:5) (f:6 | g:7)~0.1
+(def test-query
+  (let [qb (BooleanQuery$Builder.)]
+    (doto qb
+      (.add (TermQuery. (Term. "a" "1")) BooleanClause$Occur/SHOULD)
+      (.add (let [qb2 (BooleanQuery$Builder.)]
+              (doto qb2
+                (.add (TermQuery. (Term. "b" "2")) BooleanClause$Occur/MUST)
+                (.add (TermQuery. (Term. "c" "3")) BooleanClause$Occur/MUST))
+              (.build qb2))
+            BooleanClause$Occur/SHOULD)
+      (.add (BoostQuery. (TermQuery. (Term. "d" "4")) 2.0) BooleanClause$Occur/SHOULD)
+      (.add (ConstantScoreQuery. (TermQuery. (Term. "e" "5"))) BooleanClause$Occur/SHOULD)
+      (.add (DisjunctionMaxQuery. [(TermQuery. (Term. "f" "6"))
+                                   (TermQuery. (Term. "g" "7"))]
+                                  0.1)
+            BooleanClause$Occur/SHOULD))
+    (.build qb)))
+
+(fact "walk"
+  (query/walk identity identity test-query) => test-query
+  (query/walk identity identity test-query) => #(instance? Query %)
+  (query/walk identity identity nil) => nil?)
+
+(facts "postwalk"
+  (query/postwalk identity test-query) => #(instance? Query %)
+  (query/postwalk identity nil) => nil?
+  (fact "traversal order"
+    (let [xs (atom [])]
+      (query/postwalk (fn [x] (swap! xs conj (str x)) x) test-query)
+      @xs)
+    => ["a:1"
+        "b:2"
+        "c:3"
+        "+b:2 +c:3"
+        "d:4"
+        "(d:4)^2.0"
+        "e:5"
+        "ConstantScore(e:5)"
+        "f:6"
+        "g:7"
+        "(f:6 | g:7)~0.1"
+        "a:1 (+b:2 +c:3) (d:4)^2.0 ConstantScore(e:5) (f:6 | g:7)~0.1"])
+  (fact "transform"
+    (str
+     (query/postwalk
+      (fn [x]
+        (condp instance? x
+          TermQuery (let [^Term t (.getTerm ^TermQuery x)]
+                      (TermQuery. (Term. (.field t) (-> (Integer/parseInt (.text t)) inc str))))
+          BoostQuery nil
+          ConstantScoreQuery (let [^TermQuery q (.getQuery ^ConstantScoreQuery x)
+                                   ^Term t (.getTerm q)]
+                               (ConstantScoreQuery. (TermQuery. (Term. "z" (.text t)))))
+          x))
+      test-query))
+    => "a:2 (+b:3 +c:4) ConstantScore(z:6) (f:7 | g:8)~0.1"))
+
+(facts "prewalk"
+  (query/prewalk identity test-query) => #(instance? Query %)
+  (query/prewalk identity nil) => nil?
+  (fact "traversal order"
+    (let [xs (atom [])]
+      (query/prewalk (fn [x] (swap! xs conj (str x)) x) test-query)
+      @xs)
+    => ["a:1 (+b:2 +c:3) (d:4)^2.0 ConstantScore(e:5) (f:6 | g:7)~0.1"
+        "a:1"
+        "+b:2 +c:3"
+        "b:2"
+        "c:3"
+        "(d:4)^2.0"
+        "d:4"
+        "ConstantScore(e:5)"
+        "e:5"
+        "(f:6 | g:7)~0.1"
+        "f:6"
+        "g:7"])
+  (fact "transform"
+    (str
+     (query/prewalk
+      (fn [x]
+        (condp instance? x
+          TermQuery (let [^Term t (.getTerm ^TermQuery x)]
+                      (TermQuery. (Term. (.field t) (-> (Integer/parseInt (.text t)) inc str))))
+          BoostQuery nil
+          ConstantScoreQuery (let [^TermQuery q (.getQuery ^ConstantScoreQuery x)
+                                   ^Term t (.getTerm q)]
+                               (ConstantScoreQuery. (TermQuery. (Term. "z" (.text t)))))
+          x))
+      test-query))
+    => "a:2 (+b:3 +c:4) ConstantScore(z:6) (f:7 | g:8)~0.1"))


### PR DESCRIPTION
Adds walkers for a `Query` instance to new `clucie.query` namespace, which are similar to `clojure.walk`.

Lucene query is sometimes nested and complicated because of wrapper queries such as `BooleanQuery` and `BoostQuery`. `clucie.query/{post,pre}walk` makes it fairly easy to search and transform such a nested query.

The following example makes `TermQuery` text incremental and removes `BoostQuery` from the original query.

```clojure
;; query: "a:1 (+b:2 +c:3) (d:4)^2.0"
(clucie.query/postwalk
 (fn [x]
   (condp instance? x
     TermQuery (let [t (.getTerm x)]
                 (TermQuery. (Term. (.field t) (-> (Integer/parseInt (.text t)) inc str))))
     BoostQuery nil
     x))
 query)
;;=> #object[org.apache.lucene.search.BooleanQuery "0xae19d62" "a:2 (+b:3 +c:4)"]
```

`clucie.query/{post,pre}walk-demo` can be used for checking structure quickly.

```clojure
;; query: "a:1 (+b:2 +c:3) (d:4)^2.0"
(clucie.query/prewalk-demo query)
;; Walked: #object[org.apache.lucene.search.BooleanQuery 0x43392274 "a:1 (+b:2 +c:3) (d:4)^2.0"]
;; Walked: #object[org.apache.lucene.search.TermQuery 0x2c8ee184 "a:1"]
;; Walked: #object[org.apache.lucene.search.BooleanQuery 0x29952b6b "+b:2 +c:3"]
;; Walked: #object[org.apache.lucene.search.TermQuery 0x669fd30d "b:2"]
;; Walked: #object[org.apache.lucene.search.TermQuery 0x6c3f7728 "c:3"]
;; Walked: #object[org.apache.lucene.search.BoostQuery 0x37e629ea "(d:4)^2.0"]
;; Walked: #object[org.apache.lucene.search.TermQuery 0x37a8820e "d:4"]
;;=> #object[org.apache.lucene.search.BooleanQuery "0x2f37384d" "a:1 (+b:2 +c:3) (d:4)^2.0"]
```