### PR TITLE
Extensible query-form parser

### DIFF
--- a/src/clucie/core.clj
+++ b/src/clucie/core.clj
@@ -2,11 +2,9 @@
   (:require [clucie.store :as store]
             [clucie.analysis :refer [standard-analyzer]]
             [clucie.document :as doc]
-            [clucie.queryparser :as qp])
-  (:import [org.apache.lucene.document Document Field]
-           [org.apache.lucene.util QueryBuilder]
-           [org.apache.lucene.index IndexWriter IndexReader IndexOptions Term]
-           [org.apache.lucene.search BooleanClause BooleanClause$Occur BooleanQuery IndexSearcher Query PhraseQuery PhraseQuery$Builder WildcardQuery ScoreDoc TopDocs]
+            [clucie.query :as q])
+  (:import [org.apache.lucene.index IndexWriter IndexReader IndexOptions Term]
+           [org.apache.lucene.search IndexSearcher ScoreDoc TopDocs]
            [org.apache.lucene.store Directory]))
 
 (defn- stringify-value
@@ -76,37 +74,6 @@
                     (into-array [(Term. (name search-key) (stringify-value search-val))]))
   nil)
 
-(defn- query-form->query
-  [mode query-form ^QueryBuilder builder & {:keys [current-key]
-                                       :or {current-key nil}}]
-  (cond
-    (instance? Query query-form) query-form
-    (sequential? query-form) (let [qb (new org.apache.lucene.search.BooleanQuery$Builder)]
-                               (doseq [q (map #(query-form->query mode % builder :current-key current-key) query-form)]
-                                 (when q
-                                   (.add qb q BooleanClause$Occur/MUST)))
-                               (.build qb))
-    (set? query-form) (let [qb (new org.apache.lucene.search.BooleanQuery$Builder)]
-                        (doseq [q (map #(query-form->query mode % builder :current-key current-key) query-form)]
-                          (when q
-                            (.add qb q BooleanClause$Occur/SHOULD)))
-                        (.build qb))
-    (map? query-form) (let [qb (new org.apache.lucene.search.BooleanQuery$Builder)]
-                        (doseq [q (->> query-form
-                                       (map (fn [[k v]]
-                                              (query-form->query mode v builder :current-key k)))
-                                       (filter identity))]
-                          (.add qb q BooleanClause$Occur/MUST))
-                        (.build qb))
-    (string? query-form) (case mode
-                           :query (.createBooleanQuery builder (name current-key) query-form)
-                           :phrase-query (.createPhraseQuery builder (name current-key) query-form)
-                           :wildcard-query (WildcardQuery. (Term. (name current-key) ^String query-form))
-                           :qp-query (qp/parse-query (.getAnalyzer builder)
-                                                     (name current-key)
-                                                     query-form)
-                           (throw (ex-info "invalid mode" {:mode mode})))))
-
 (defmulti ^:private search* #(class (second %&)))
 
 (defmethod search* Directory
@@ -120,8 +87,7 @@
         page (or page 0)
         results-per-page (or results-per-page max-results)
         ^IndexSearcher searcher (IndexSearcher. reader)
-        builder (QueryBuilder. analyzer)
-        ^Query query (query-form->query mode query-form builder)
+        query (q/parse-form query-form :analyzer analyzer :mode mode)
         ^TopDocs hits (.search searcher query (int max-results))
         start (* page results-per-page)
         end (min (+ start results-per-page) (.totalHits hits) max-results)]

--- a/src/clucie/query.clj
+++ b/src/clucie/query.clj
@@ -1,7 +1,82 @@
 (ns clucie.query
-  (:import [org.apache.lucene.search
-            BooleanClause BooleanQuery BooleanQuery$Builder BoostQuery
-            ConstantScoreQuery DisjunctionMaxQuery Query]))
+  (:require [clucie.analysis :as analysis]
+            [clucie.queryparser :as qp])
+  (:import [org.apache.lucene.index Term]
+           [org.apache.lucene.search
+            BooleanClause BooleanClause$Occur BooleanQuery BooleanQuery$Builder
+            BoostQuery ConstantScoreQuery DisjunctionMaxQuery Query WildcardQuery]
+           [org.apache.lucene.util QueryBuilder]))
+
+(defprotocol FormParsable
+  (parse-formt [form options]))
+
+(extend-protocol FormParsable
+  Query
+  (parse-formt [query _] query)
+
+  clojure.lang.Sequential
+  (parse-formt [xs options]
+    (let [qb (BooleanQuery$Builder.)]
+      (doseq [q (keep #(parse-formt % options) xs)]
+        (.add qb q BooleanClause$Occur/MUST))
+      (.build qb)))
+
+  clojure.lang.IPersistentSet
+  (parse-formt [coll options]
+    (let [qb (BooleanQuery$Builder.)]
+      (doseq [q (keep #(parse-formt % options) coll)]
+        (.add qb q BooleanClause$Occur/SHOULD))
+      (.build qb)))
+
+  clojure.lang.IPersistentMap
+  (parse-formt [coll options]
+    (let [qb (BooleanQuery$Builder.)]
+      (doseq [q (keep (fn [[k v]] (parse-formt v (assoc options :key k))) coll)]
+        (.add qb q BooleanClause$Occur/MUST))
+      (.build qb)))
+
+  String
+  (parse-formt [s {:keys [^QueryBuilder builder mode key]}]
+    (case mode
+      :query (.createBooleanQuery builder (name key) s)
+      :phrase-query (.createPhraseQuery builder (name key) s)
+      :wildcard-query (WildcardQuery. (Term. (name key) s))
+      :qp-query (qp/parse-query (.getAnalyzer builder) (name key) s)
+      (throw (ex-info (str "Invalid mode " mode) {:mode mode})))))
+
+(defn ^Query parse-form
+  "Parses form, returning an org.apache.lucene.search.Query.
+
+  The form is parsed according to the following rules:
+
+    org.apache.lucene.search.Query => as is
+    [query1 query2] => query1 AND query2
+    #{query1 query2} => query1 OR query2
+    {:field \"value\"} => query(field:value)
+
+  Options:
+
+    {:analyzer  An org.apache.lucene.analysis.Analyzer instance used for building
+                query from string, default (clucie.analysis/standard-analyzer).
+     :mode      Changes the behavior of parsing string, default :query.
+                <:query|:phrase-query|:wildcard-query|:qp-query>}
+
+  You can extend the behavior of parse-form by implementing parse-formt of
+  FormParsable protocol. For example,
+
+    (extend-protocol clucie.query/FormParsable
+      java.util.regex.Pattern
+      (parse-formt [re {:keys [key]}]
+        (org.apache.lucene.search.RegexpQuery.
+         (org.apache.lucene.index.Term. (name key) (.pattern re)))))
+
+  adds a new rule that builds an org.apache.lucene.search.RegexpQuery from a
+  regexp."
+  [form & {:keys [analyzer mode] :or {analyzer (analysis/standard-analyzer)
+                                      mode :query}}]
+  (parse-formt form {:builder (QueryBuilder. analyzer)
+                     :mode mode
+                     :key nil}))
 
 (defn ^Query walk
   "Traverses query. inner and outer are functions. Applies inner to each


### PR DESCRIPTION
I reimplemented the query-form parser with protocol.

An advantage of the new parser is user-side extensibility. A user can extend the behavior of the parser by implementing `parse-formt` of `FormParsable` protocol. For example,

```clojure
(require '[clucie.query :as query])

(import 'org.apache.lucene.index.Term
        'org.apache.lucene.search.RegexpQuery)

(extend-protocol query/FormParsable
  java.util.regex.Pattern
  (parse-formt [re {:keys [key]}]
    (RegexpQuery. (Term. (name key) (.pattern re)))))
```

adds a new rule that builds a `RegexpQuery` from a regexp.

```clojure
(query/parse-form {:foo #"[mb]oat"})
;;=> #object[org.apache.lucene.search.BooleanQuery "0x6e252bbc" "+foo:/[mb]oat/"]
```