### PR TITLE
Add total-hits to metadata of results

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,17 @@ Clojure for the Lucene
 
 ;; => [{:number "1", :title "Please Please Me"} {:number "2", :title "With the Beatles"} {:number "4", :title "Beatles for Sale"}]
 
-;; Get score
+;; Get meta information
 (let [results (core/search index-store
                            {:title #{"Beatles" "Please"}}
                            10
                            analyzer
                            0
                            5)]
-  (map #(:score (meta %)) results))
-
-;; => (0.62241787 0.3930676 0.3930676)
+  ;; the total number of hits
+  (prn (:total-hits (meta results))) ; => 3
+  ;; scores
+  (prn (map #(:score (meta %)) results))) ; => (0.62241787 0.3930676 0.3930676)
 
 (store/close! index-store)
 ```

--- a/src/clucie/core.clj
+++ b/src/clucie/core.clj
@@ -125,12 +125,14 @@
         ^TopDocs hits (.search searcher query (int max-results))
         start (* page results-per-page)
         end (min (+ start results-per-page) (.totalHits hits) max-results)]
-    (vec
-     (for [^ScoreDoc hit (map (partial aget (.scoreDocs hits))
-                              (range start end))]
-       (let [m (doc/document->map (.doc searcher (.doc hit)))
-             score (.score hit)]
-         (with-meta m {:score score}))))))
+    (with-meta
+      (vec
+       (for [^ScoreDoc hit (map (partial aget (.scoreDocs hits))
+                                (range start end))]
+         (let [m (doc/document->map (.doc searcher (.doc hit)))
+               score (.score hit)]
+           (with-meta m {:score score}))))
+      {:total-hits (.totalHits hits)})))
 
 (defn search
   "Search the supplied index with a query string."

--- a/test/clucie/t_common.clj
+++ b/test/clucie/t_common.clj
@@ -116,12 +116,18 @@
     (reset! test-store store)
     (add-entries! (apply concat target-entries))))
 
+(defn- assert-total-hits [results]
+  (let [{:keys [total-hits]} (meta results)]
+    (assert (integer? total-hits))
+    (assert (>= total-hits 0))))
+
 (defn all-results-has-score? [results]
   (doseq [r results]
     (assert (number? (:score (meta r))))))
 
 (defn results-is-valid? [quantity & [entry-key]]
   (fn [results]
+    (assert-total-hits results)
     (all-results-has-score? results)
     (if (or (zero? quantity) (not entry-key))
       (= quantity (count results))


### PR DESCRIPTION
Adds the total number of hits (`:total-hits`) to metadata of a results vector. It is sometimes useful for general search engines.