### PR TITLE
Add doc-id metadata

### DIFF
--- a/src/clucie/core.clj
+++ b/src/clucie/core.clj
@@ -128,9 +128,10 @@
     (vec
      (for [^ScoreDoc hit (map (partial aget (.scoreDocs hits))
                               (range start end))]
-       (let [m (doc/document->map (.doc searcher (.doc hit)))
+       (let [doc-id (.doc hit)
+             m (doc/document->map (.doc searcher doc-id))
              score (.score hit)]
-         (with-meta m {:score score}))))))
+         (with-meta m {:score score :doc-id doc-id}))))))
 
 (defn search
   "Search the supplied index with a query string."


### PR DESCRIPTION
This branch adds `:doc-id` meta data that contains an ID of a hit document related to the index store.
This ID is useful for getting an `Explanation` objects of a document.