### PR TITLE
Update to Lucene 7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,14 +4,14 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :min-lein-version "2.5.0"
-  :dependencies [[org.apache.lucene/lucene-core "6.6.3"]
-                 [org.apache.lucene/lucene-analyzers-common "6.6.3"]
-                 [org.apache.lucene/lucene-analyzers-icu "6.6.3"]
-                 [org.apache.lucene/lucene-analyzers-kuromoji "6.6.3"]
-                 [org.apache.lucene/lucene-analyzers-phonetic "6.6.3"]
-                 [org.apache.lucene/lucene-analyzers-smartcn "6.6.3"]
-                 [org.apache.lucene/lucene-analyzers-stempel "6.6.3"]
-                 [org.apache.lucene/lucene-queryparser "6.6.3"]]
+  :dependencies [[org.apache.lucene/lucene-core "7.3.0"]
+                 [org.apache.lucene/lucene-analyzers-common "7.3.0"]
+                 [org.apache.lucene/lucene-analyzers-icu "7.3.0"]
+                 [org.apache.lucene/lucene-analyzers-kuromoji "7.3.0"]
+                 [org.apache.lucene/lucene-analyzers-phonetic "7.3.0"]
+                 [org.apache.lucene/lucene-analyzers-smartcn "7.3.0"]
+                 [org.apache.lucene/lucene-analyzers-stempel "7.3.0"]
+                 [org.apache.lucene/lucene-queryparser "7.3.0"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [midje "1.9.1"]]
                    :plugins [[lein-cloverage "1.0.10"]

--- a/src/clucie/queryparser.clj
+++ b/src/clucie/queryparser.clj
@@ -5,6 +5,8 @@
 
 (defn ^Query parse-query
   [^Analyzer analyzer ^String default-field-name ^String query-string]
-  (let [^QueryParser qp (QueryParser. default-field-name analyzer)
-        _ (.setAutoGeneratePhraseQueries qp true)]
+  (let [^QueryParser qp (QueryParser. default-field-name analyzer)]
+    (doto qp
+      (.setSplitOnWhitespace true)
+      (.setAutoGeneratePhraseQueries true))
     (.parse qp query-string)))


### PR DESCRIPTION
Updates Lucene modules to 7.3.0.

`clucie.queryparser` is a bit changed because

> The combination splitOnWhitespace=false and autoGeneratePhraseQueries=true is disallowed.

cf. https://lucene.apache.org/core/7_3_0/queryparser/org/apache/lucene/queryparser/classic/QueryParser.html#setAutoGeneratePhraseQueries-boolean-